### PR TITLE
T42 - Provision OpenShift GitOps using ClusterResourceSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,12 @@ Before applying any of the manifests to create a new cluster(s), the following p
 ### Management Cluster 
 In order to deploy a new OpenShift Cluster using CAPI, you will need a management cluster with the necessary CAPI and CAPA deployments in an operational state. 
 
-#### Install Tools
 To get started, install the following tools on your local machine:
  - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) 
  - [clusterawsadm](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases) CLI tool
  - [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) CLI tool
  - kubectl and/or oc CLI tool
  - [helm](https://helm.sh/docs/intro/quickstart/#install-helm)
-
-#### Install a Kubernetes Cluster or Login to existing Cluster
-
-ClusterAPI requires an existing kubernetes cluster accessible via Kubectl that will be transformed into a management cluster by the clusterctl command. 
-
-You can either log in to an existing Openshift Cluster to establish the current-context or launch a local kind cluster for this purpose.
-
-#### Prepare Environment & Management Cluster
 
 Run the following commands to prepare the environment and management cluster:
 ```
@@ -60,7 +51,6 @@ Run the following commands to prepare the environment and management cluster:
   clusterctl init --infrastructure aws
 ```
 
-#### Customize Openshift (Optional)
 Apply customizations provided by this repo:
 
 **_Optional_**: This step is needed if your mangement cluster is an OpenShift Cluster
@@ -68,8 +58,6 @@ Apply customizations provided by this repo:
 ```
   helm template --release-name rosa-hcp charts/openshift-management | oc apply -f -
 ```
-
-#### Validate Management Cluster  
 
 Make sure the CAPI pods are operational before running the next apply. <br />
 This can be done by checking the output of the following commands:
@@ -81,14 +69,13 @@ This can be done by checking the output of the following commands:
   oc get pods -n capi-kubeadm-control-plane-system
 ```
 
-#### Configure CAPI
 Apply CAPI specific configurations needed to support the upcoming workloads:
 
 ```
   helm template charts/capi-management | oc apply -f -
 ```
 
-#### Validate ROSA Specifics
+
 Run the following command to validate that everything is set up correctly, and ready for your first ROSA HCP cluster deployment with CAPI (all commands should return output containing the values in the grep part of the command):
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,12 +31,21 @@ Before applying any of the manifests to create a new cluster(s), the following p
 ### Management Cluster 
 In order to deploy a new OpenShift Cluster using CAPI, you will need a management cluster with the necessary CAPI and CAPA deployments in an operational state. 
 
+#### Install Tools
 To get started, install the following tools on your local machine:
  - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) 
  - [clusterawsadm](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases) CLI tool
  - [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) CLI tool
  - kubectl and/or oc CLI tool
  - [helm](https://helm.sh/docs/intro/quickstart/#install-helm)
+
+#### Install a Kubernetes Cluster or Login to existing Cluster
+
+ClusterAPI requires an existing kubernetes cluster accessible via Kubectl that will be transformed into a management cluster by the clusterctl command. 
+
+You can either log in to an existing Openshift Cluster to establish the current-context or launch a local kind cluster for this purpose.
+
+#### Prepare Environment & Management Cluster
 
 Run the following commands to prepare the environment and management cluster:
 ```
@@ -51,6 +60,7 @@ Run the following commands to prepare the environment and management cluster:
   clusterctl init --infrastructure aws
 ```
 
+#### Customize Openshift (Optional)
 Apply customizations provided by this repo:
 
 **_Optional_**: This step is needed if your mangement cluster is an OpenShift Cluster
@@ -58,6 +68,8 @@ Apply customizations provided by this repo:
 ```
   helm template --release-name rosa-hcp charts/openshift-management | oc apply -f -
 ```
+
+#### Validate Management Cluster  
 
 Make sure the CAPI pods are operational before running the next apply. <br />
 This can be done by checking the output of the following commands:
@@ -69,13 +81,14 @@ This can be done by checking the output of the following commands:
   oc get pods -n capi-kubeadm-control-plane-system
 ```
 
+#### Configure CAPI
 Apply CAPI specific configurations needed to support the upcoming workloads:
 
 ```
   helm template charts/capi-management | oc apply -f -
 ```
 
-
+#### Validate ROSA Specifics
 Run the following command to validate that everything is set up correctly, and ready for your first ROSA HCP cluster deployment with CAPI (all commands should return output containing the values in the grep part of the command):
 
 ```

--- a/charts/rosa-capi/templates/Cluster.yaml
+++ b/charts/rosa-capi/templates/Cluster.yaml
@@ -3,6 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "rosa-capi.fullname" . }}
+  namespace: {{ default "default" .Values.namespace }}
   labels:
     {{- include "rosa-capi.labels" . | nindent 4 }}
 spec:

--- a/charts/rosa-capi/templates/ROSACluster.yaml
+++ b/charts/rosa-capi/templates/ROSACluster.yaml
@@ -3,6 +3,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: ROSACluster
 metadata:
   name: {{ include "rosa-capi.fullname" . }}
+  namespace: {{ default "default" .Values.namespace }}
   labels:
     {{- include "rosa-capi.labels" . | nindent 4 }}
 spec: {}

--- a/charts/rosa-capi/templates/ROSAControlPlane.yaml
+++ b/charts/rosa-capi/templates/ROSAControlPlane.yaml
@@ -3,6 +3,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: ROSAControlPlane
 metadata:
   name: {{ include "rosa-capi.fullname" . }}-control-plane
+  namespace: {{ default "default" .Values.namespace }}
   labels:
     {{- include "rosa-capi.labels" . | nindent 4 }}
 spec:

--- a/charts/rosa-capi/templates/_helpers.tpl
+++ b/charts/rosa-capi/templates/_helpers.tpl
@@ -36,6 +36,11 @@ Common labels
 {{- define "rosa-capi.labels" -}}
 helm.sh/chart: {{ include "rosa-capi.chart" . }}
 {{ include "rosa-capi.selectorLabels" . }}
+{{- if .Values.enable_argocd }}
+enable_argocd: "yes"
+{{- else }}
+enable_argocd: "no"    
+{{- end }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/charts/rosa-capi/templates/_helpers.tpl
+++ b/charts/rosa-capi/templates/_helpers.tpl
@@ -36,15 +36,11 @@ Common labels
 {{- define "rosa-capi.labels" -}}
 helm.sh/chart: {{ include "rosa-capi.chart" . }}
 {{ include "rosa-capi.selectorLabels" . }}
-{{- if .Values.enable_argocd }}
-enable_argocd: "yes"
-{{- else }}
-enable_argocd: "no"    
-{{- end }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+rosa-capi/clusternName: {{ include "rosa-capi.name" . }}
 {{- end }}
 
 {{/*

--- a/charts/rosa-capi/templates/_helpers.tpl
+++ b/charts/rosa-capi/templates/_helpers.tpl
@@ -40,7 +40,7 @@ helm.sh/chart: {{ include "rosa-capi.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-rosa-capi/clusternName: {{ include "rosa-capi.name" . }}
+rosa-capi/clusterName: {{ include "rosa-capi.name" . }}
 {{- end }}
 
 {{/*

--- a/charts/rosa-capi/templates/openshift-gitops.yaml
+++ b/charts/rosa-capi/templates/openshift-gitops.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enable_argocd }}
+{{- if .Values.enableArgoCD }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/rosa-capi/templates/openshift-gitops.yaml
+++ b/charts/rosa-capi/templates/openshift-gitops.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enable_argocd }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -211,3 +212,4 @@ data:
         dex:
           openShiftOAuth: true
         provider: dex
+{{- end }}

--- a/charts/rosa-capi/templates/openshift-gitops.yaml
+++ b/charts/rosa-capi/templates/openshift-gitops.yaml
@@ -1,0 +1,213 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshift-gitops
+  namespace: {{ default "default" .Values.namespace }}
+data:
+  argocd.yaml: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/component: application-controller
+        app.kubernetes.io/name: argocd-application-controller
+        app.kubernetes.io/part-of: openshift-gitops
+      name: argocd-application-controller
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/component: argocd-server
+        app.kubernetes.io/name: gitops-argocd-server
+        app.kubernetes.io/part-of: openshift-gitops
+      name: gitops-argocd-server
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - delete  # supports deletion a live object in UI
+      - get     # supports viewing live object manifest in UI
+      - patch   # supports `argocd app patch`
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - list    # supports listing events in UI
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - pods/log
+      verbs:
+      - get     # supports viewing pod logs from UI
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: application-controller
+        app.kubernetes.io/name: argocd-application-controller
+        app.kubernetes.io/part-of: openshift-gitops
+      name: argocd-application-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: argocd-application-controller
+    subjects:
+    - kind: ServiceAccount
+      name: argocd-argocd-application-controller
+      namespace: openshift-gitops
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: argocd-server
+        app.kubernetes.io/name: argocd-server
+        app.kubernetes.io/part-of: openshift-gitops
+      name: argocd-server
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: gitops-argocd-server
+    subjects:
+    - kind: ServiceAccount
+      name: argocd-argocd-server
+      namespace: openshift-gitops
+    ---
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: openshift-gitops-operator
+      namespace: openshift-operators
+    spec:
+      channel: latest
+      installPlanApproval: Automatic
+      name: openshift-gitops-operator
+      source: "redhat-operators"
+      sourceNamespace: "openshift-marketplace"
+      config:
+        env:
+        - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+          value:  "true"
+        - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+          value: "openshift-gitops"
+    ---
+    # Source: gitops-operator/templates/crd-reader.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: crd-reader
+    rules:
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - 'customresourcedefinitions'
+      verbs:
+      - get
+      - list
+    ---
+    # Source: gitops-operator/templates/crd-reader.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: crd-reader-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: crd-reader
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: openshift-gitops
+    ---
+    # Source: gitops-operator/templates/wait-for-crd.yaml
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: cluster-check 
+      namespace: openshift-gitops
+    spec:
+      containers:
+      - name: crd-check 
+        image: quay.io/openshift/origin-cli:latest
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io applications.argoproj.io appprojects.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 0
+      serviceAccount: default
+      serviceAccountName: default
+    ---
+    # Source: gitops-operator/templates/argocd-cr.yaml
+    apiVersion: argoproj.io/v1alpha1
+    kind: AppProject
+    metadata:
+      name: default
+      annotations:
+        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook-weight": "25"
+      namespace: openshift-gitops
+    spec:
+      clusterResourceWhitelist:
+        - group: '*'
+          kind: '*'
+      destinations:
+        - namespace: '*'
+          server: '*'
+      sourceRepos:
+        - '*'
+    status: {}
+    ---
+    # Source: gitops-operator/templates/argocd-cr.yaml
+    apiVersion: argoproj.io/v1beta1
+    kind: ArgoCD
+    metadata:
+      name: argocd
+      labels:
+        app: argocd
+      namespace: openshift-gitops
+    spec:
+      applicationInstanceLabelKey: rht-gitops.com/openshift-gitops
+      applicationSet: {}
+      notifications:
+        enabled: true
+      rbac:
+        defaultPolicy: role:admin
+        policy: |
+          g, system:cluster-admins, role:admin
+        scopes: '[groups]'
+      repositoryCredentials: null
+      resourceExclusions: |
+        - apiGroups:
+            - tekton.dev
+          clusters:
+            - '*'
+          kinds:
+            - TaskRun
+            - PipelineRun
+      server:
+        ingress:
+          enabled: false
+        route:
+          enabled: true
+          tls:
+            termination: reencrypt
+      sso:
+        dex:
+          openShiftOAuth: true
+        provider: dex

--- a/charts/rosa-capi/templates/opensift-gitops-cluster-resource-set.yaml
+++ b/charts/rosa-capi/templates/opensift-gitops-cluster-resource-set.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enable_argocd }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -7,7 +8,8 @@ spec:
   strategy: ApplyOnce
   clusterSelector:
     matchLabels:
-      enable_argocd: "yes"
+      rosa-capi/clusternName: {{ include "rosa-capi.name" . }}
   resources:
     - name: openshift-gitops
       kind: ConfigMap
+{{- end }}

--- a/charts/rosa-capi/templates/opensift-gitops-cluster-resource-set.yaml
+++ b/charts/rosa-capi/templates/opensift-gitops-cluster-resource-set.yaml
@@ -1,0 +1,13 @@
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: openshift-gitops-crs
+  namespace: {{ default "default" .Values.namespace }}
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      enable_argocd: "yes"
+  resources:
+    - name: openshift-gitops
+      kind: ConfigMap

--- a/charts/rosa-capi/templates/opensift-gitops-cluster-resource-set.yaml
+++ b/charts/rosa-capi/templates/opensift-gitops-cluster-resource-set.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enable_argocd }}
+{{- if .Values.enableArgoCD }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -8,7 +8,7 @@ spec:
   strategy: ApplyOnce
   clusterSelector:
     matchLabels:
-      rosa-capi/clusternName: {{ include "rosa-capi.name" . }}
+      rosa-capi/clusterName: {{ include "rosa-capi.name" . }}
   resources:
     - name: openshift-gitops
       kind: ConfigMap

--- a/charts/rosa-capi/values.yaml
+++ b/charts/rosa-capi/values.yaml
@@ -1,7 +1,10 @@
 # Default values for rosa-capi.
 
-# Set the value to tru if you need ArgoCd to be installed on the new cluster
+# Set the value to true if you need ArgoCd to be installed on the new cluster
 enable_argocd: false
+
+# Set namespace where you want the cluster to be installed
+namespace: default
 
 # nameOverride: my-test-cluster
 fullnameOverride: my-test-cluster

--- a/charts/rosa-capi/values.yaml
+++ b/charts/rosa-capi/values.yaml
@@ -1,5 +1,8 @@
 # Default values for rosa-capi.
 
+# Set the value to tru if you need ArgoCd to be installed on the new cluster
+enable_argocd: false
+
 # nameOverride: my-test-cluster
 fullnameOverride: my-test-cluster
 

--- a/charts/rosa-capi/values.yaml
+++ b/charts/rosa-capi/values.yaml
@@ -1,7 +1,7 @@
 # Default values for rosa-capi.
 
 # Set the value to true if you need ArgoCd to be installed on the new cluster
-enable_argocd: false
+enableArgoCD: false
 
 # Set namespace where you want the cluster to be installed
 namespace: default


### PR DESCRIPTION
This implementation adds a ConfigMap with ArgoCd manifests and a ClusterResourceSet to allow ArgoCd to be added to a managed cluster.

A boolean entry on values.yaml called enable_argocd controls the installation of ArgoCd on the managed cluster. 